### PR TITLE
Adding a raw mode to send event without wrapping to Splunk

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 meni3a
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,7 @@ To enable and configure BatchMode in your application set:
  - error
  - fatal
  - debug
-
-  
-
+ - raw (for sending raw data directly to Splunk)
 
 ## License
 

--- a/lib/classes/SplunkLogger.ts
+++ b/lib/classes/SplunkLogger.ts
@@ -1,9 +1,9 @@
-import { ConsoleColors } from "../enums/ConsoleColors";
-import { SplunkRequest } from "./SplunkRequest";
-import { LogLevel } from "../enums/LogType";
-import { LogTypeToColor } from "../utils/LogTypeToColor";
-import { SplunkPayload } from "../types/SplunkPayload";
-import { SplunkLoggerOptions } from "./SplunkLoggerOptions";
+import {ConsoleColors} from "../enums/ConsoleColors";
+import {SplunkRequest} from "./SplunkRequest";
+import {LogLevel} from "../enums/LogType";
+import {LogTypeToColor} from "../utils/LogTypeToColor";
+import {SplunkPayload} from "../types/SplunkPayload";
+import {SplunkLoggerOptions} from "./SplunkLoggerOptions";
 
 
 export class SplunkLogger{ 
@@ -78,7 +78,7 @@ export class SplunkLogger{
 
     private handleLog(type: LogLevel, message: any):void {
 
-        const splunkPayload:SplunkPayload = {event:{ type, message }};
+        const splunkPayload:SplunkPayload = type === LogLevel.RAW ? message : {event:{ type, message }};
 
         if (this.options.shouldPrintLogs) {
             let color = LogTypeToColor[type];
@@ -112,5 +112,5 @@ export class SplunkLogger{
     public fatal(message: any) { this.handleLog(LogLevel.FATAL, message); }
 
     public debug(message: any) { this.handleLog(LogLevel.DEBUG, message); }
-
+    public raw(message: any) { this.handleLog(LogLevel.RAW, message); }
 }

--- a/lib/enums/LogType.ts
+++ b/lib/enums/LogType.ts
@@ -6,4 +6,5 @@ export enum LogLevel {
     DEBUG = "DEBUG",
     INITIAL = "INITIAL",
     HTTP = "HTTP",
+    RAW = "RAW"
 }

--- a/lib/utils/LogTypeToColor.ts
+++ b/lib/utils/LogTypeToColor.ts
@@ -9,4 +9,5 @@ export const LogTypeToColor : Record<LogLevel,ConsoleColors> = {
     [LogLevel.DEBUG]: ConsoleColors.Cyan,
     [LogLevel.INITIAL]: ConsoleColors.Regular,
     [LogLevel.HTTP]: ConsoleColors.Cyan,
+    [LogLevel.RAW]: ConsoleColors.Regular,
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "HEC"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/meni3a/splunk-logger/issues"
   },


### PR DESCRIPTION
Loving the library, very handy. 
For some use cases I need to send the whole Splunk message including index & source definition. Therefore suggesting a RAW mode to facilitate this.

* Adding a raw mode to send event without wrapping to Splunk
* Adding license file