### PR TITLE
* Adding option to throw Exceptions when calls are failing instead of doing only a console.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ const options = new SplunkLoggerOptions({
     batchOptions: {
         batchSize: 500, 
         queueSizeLimit: 10000 
-    }
+    },
+    exceptionOnFailure: false
 });
 
 const logger = new SplunkLogger(options)
@@ -94,6 +95,11 @@ BatchMode is particularly useful for applications that generate a large volume o
 To enable and configure BatchMode in your application set:
 ```js
     isBatchingEnabled: true
+```
+
+To enable to receive exceptions when sending data to splunk fails set:
+```js
+    exceptionOnFailure: true
 ```
 
 ## Log levels

--- a/lib/classes/SplunkLoggerOptions.ts
+++ b/lib/classes/SplunkLoggerOptions.ts
@@ -14,6 +14,7 @@ export class SplunkLoggerOptions {
     shouldPrintLogs?: boolean;
     isBatchingEnabled?: boolean = false;
     batchOptions?: BatchOptions;
+    exceptionOnFailure?: boolean = false;
 
     private isWinstonTransport?: boolean = false;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "splunk-logger",
       "version": "2.0.8",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "winston-transport": "^4.6.0"


### PR DESCRIPTION
In some circumstances it is required that the wrapping app knows about errors while sending logs to Splunk